### PR TITLE
Copied routes not created with recursive imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /.composer/
+/.idea/
+/.php_cs.cache
 /composer.lock
 /composer.phar
 /docker-compose.yml
 /php-cs-fixer.phar
 /vendor/
+*.iml

--- a/.php_cs
+++ b/.php_cs
@@ -1,9 +1,15 @@
 <?php
-$finder = Symfony\CS\Finder\DefaultFinder::create()
+$finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/src')
     ;
 
-return Symfony\CS\Config\Config::create()
-    ->fixers(array('-empty_return', '-blankline_after_open_tag', 'ordered_use', '-phpdoc_no_empty_return'))
-    ->finder($finder)
+return PhpCsFixer\Config::create()
+    ->setRules(array(
+        '@Symfony' => true,
+        'no_useless_return' => false,
+        'blank_line_after_opening_tag' => false,
+        'ordered_imports' => true,
+        'phpdoc_no_empty_return' => false,
+    ))
+    ->setFinder($finder)
     ;

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016 KUBO Atsuhiro <kubo@iteman.jp>,
+Copyright (c) 2016-2017 KUBO Atsuhiro <kubo@iteman.jp>,
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you find a bug or have a question, or want to request a feature, create an is
 
 ## Copyright
 
-Copyright (c) 2016 KUBO Atsuhiro, All rights reserved.
+Copyright (c) 2016-2017 KUBO Atsuhiro, All rights reserved.
 
 ## License
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (c) 2016 KUBO Atsuhiro <kubo@iteman.jp>,
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp>,
  * All rights reserved.
  *
  * This file is part of PHPMentorsRouteTemplatingBundle.

--- a/src/DependencyInjection/PHPMentorsRouteTemplatingExtension.php
+++ b/src/DependencyInjection/PHPMentorsRouteTemplatingExtension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (c) 2016 KUBO Atsuhiro <kubo@iteman.jp>,
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp>,
  * All rights reserved.
  *
  * This file is part of PHPMentorsRouteTemplatingBundle.

--- a/src/PHPMentorsRouteTemplatingBundle.php
+++ b/src/PHPMentorsRouteTemplatingBundle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (c) 2016 KUBO Atsuhiro <kubo@iteman.jp>,
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp>,
  * All rights reserved.
  *
  * This file is part of PHPMentorsRouteTemplatingBundle.

--- a/src/Routing/Loader/YamlFileLoader.php
+++ b/src/Routing/Loader/YamlFileLoader.php
@@ -17,9 +17,9 @@ use Symfony\Component\Routing\RouteCollection;
 class YamlFileLoader extends \Symfony\Component\Routing\Loader\YamlFileLoader
 {
     /**
-     * @var string
+     * @var array
      */
-    private $copyAs;
+    private $copyAs = [];
 
     /**
      * {@inheritdoc}
@@ -27,13 +27,14 @@ class YamlFileLoader extends \Symfony\Component\Routing\Loader\YamlFileLoader
     public function import($resource, $type = null, $ignoreErrors = false, $sourceResource = null)
     {
         $routeCollection = parent::import($resource, $type, $ignoreErrors, $sourceResource);
-        if ($this->copyAs !== null) {
+        $copyAs = $this->copyAs[count($this->copyAs) - 1];
+        if ($copyAs !== null) {
             foreach ($routeCollection->all() as $name => $route) {
-                $routeCollection->add($this->copyAs.$name, $route);
+                $routeCollection->add($copyAs.$name, $route);
                 $routeCollection->remove($name);
             }
 
-            $this->copyAs = null;
+            array_pop($this->copyAs);
         }
 
         return $routeCollection;
@@ -61,7 +62,7 @@ class YamlFileLoader extends \Symfony\Component\Routing\Loader\YamlFileLoader
      */
     protected function parseImport(RouteCollection $collection, array $config, $path, $file)
     {
-        $this->copyAs = isset($config['copy_as']) ? $config['copy_as'] : null;
+        $this->copyAs[] = isset($config['copy_as']) ? $config['copy_as'] : null;
 
         parent::parseImport($collection, $config, $path, $file);
     }

--- a/src/Routing/Loader/YamlFileLoader.php
+++ b/src/Routing/Loader/YamlFileLoader.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (c) 2016 KUBO Atsuhiro <kubo@iteman.jp>,
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp>,
  * All rights reserved.
  *
  * This file is part of PHPMentorsRouteTemplatingBundle.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | -
| License       | BSD-2-Clause

This will fix a problem that copied routes not to be created with recursive imports.
